### PR TITLE
wdio-visual-regression: fix multiple different browser width issue

### DIFF
--- a/webdriverio/wdio-visual-regression/page-objects/pages/product-description-page.js
+++ b/webdriverio/wdio-visual-regression/page-objects/pages/product-description-page.js
@@ -2,7 +2,7 @@ import Page from '../page';
 
 class PDP extends Page {
 
-  get rest_of_shelf() { return $('.product-title--container') }
+  get pdp_container() { return $('.product-details-page') }
 
   open(productId) {
     super.open(`/groceries/en-GB/products/${productId}`);

--- a/webdriverio/wdio-visual-regression/specs/product-description.js
+++ b/webdriverio/wdio-visual-regression/specs/product-description.js
@@ -6,13 +6,13 @@ const compareImages = outputs => {
 
 describe('Feature: Product Description Page', () => {
   context('Product container check', () => {
-    const productId = '254656543'
+    const productId = '253807413'
     before(() => {
       PDP.open(productId);
     });
 
     it('product container elements should be aligned properly', () => {
-      compareImages(browser.checkElement(PDP.rest_of_shelf.selector));
+      compareImages(browser.checkElement(PDP.pdp_container.selector));
     });
   });
 });

--- a/webdriverio/wdio-visual-regression/wdio.conf.js
+++ b/webdriverio/wdio-visual-regression/wdio.conf.js
@@ -2,12 +2,14 @@ const path = require('path');
 const VisualRegressionCompare = require('wdio-visual-regression-service/compare');
 function getScreenshotName(basePath) {
   return function(context) {
-    const type = context.type;
-    const testName = context.test.title;
-    const browserVersion = parseInt(context.browser.version, 10);
-    const browserName = context.browser.name;
-    const browserWidth = context.meta.viewport.width;
-    return path.join(basePath, `${testName}_${type}_${browserName}_v${browserVersion}_${browserWidth}.png`);
+    const type = context.type,
+    testName = context.test.title,
+    browserVersion = parseInt(context.browser.version, 10),
+    browserName = context.browser.name,
+    browserViewport = context.meta.viewport,
+    browserWidth = browserViewport.width,
+    browserHeight = browserViewport.height;
+    return path.join(basePath, `${testName}_${type}_${browserName}_v${browserVersion}_${browserWidth}x${browserHeight}.png`);
   };
 }
 exports.config = {
@@ -120,15 +122,15 @@ exports.config = {
     // commands. Instead, they hook themselves up into the test process.
     services: ['selenium-standalone','visual-regression'],
     visualRegression: {
-      compare: new VisualRegressionCompare.LocalCompare({
-        referenceName: getScreenshotName(path.join(process.cwd(), 'screenshots/reference')),
-        screenshotName: getScreenshotName(path.join(process.cwd(), 'screenshots/screen')),
-        diffName: getScreenshotName(path.join(process.cwd(), 'screenshots/diff')),
-        misMatchTolerance: 0.01,
-      }),
-      viewportChangePause: 300,
-      //widths: [320, 480, 640, 1024]
-      // orientations: ['landscape'],
+    compare: new VisualRegressionCompare.LocalCompare({
+      referenceName: getScreenshotName(path.join(process.cwd(), 'screenshots/reference')),
+      screenshotName: getScreenshotName(path.join(process.cwd(), 'screenshots/screen')),
+      diffName: getScreenshotName(path.join(process.cwd(), 'screenshots/diff')),
+      misMatchTolerance: 0.01,
+    }),
+    viewportChangePause: 300,
+    viewports: [{ width: 320, height: 480 }, { width: 768, height: 1024 }, { width: 1280, height: 727 }],
+    orientations: ['landscape', 'portrait'],
     },//
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber


### PR DESCRIPTION
**Issue:**
`width` options provided is not taken into account for taking screenshots and comparing them. Always taking the default width.

**Fix:**
Fixed by adding `viewports: [{ width: 320, height: 480 }, { width: 768, height: 1024 }, { width: 1280, height: 727 }]`