### PR TITLE
wdio-visual-regression: check for unavailable product

### DIFF
--- a/webdriverio/wdio-visual-regression/page-objects/pages/product-description-page.js
+++ b/webdriverio/wdio-visual-regression/page-objects/pages/product-description-page.js
@@ -1,7 +1,6 @@
 import Page from '../page';
 
 class PDP extends Page {
-
   get pdp_container() { return $('.product-details-page') }
 
   open(productId) {

--- a/webdriverio/wdio-visual-regression/specs/product-description.js
+++ b/webdriverio/wdio-visual-regression/specs/product-description.js
@@ -1,17 +1,17 @@
 import PDP from '../page-objects/pages/product-description-page';
 
 const compareImages = outputs => {
-  outputs.forEach((output, index) => expect(output.isExactSameImage, `Images are not same`).to.be.true);
+  outputs.forEach((output, index) => expect(output.isWithinMisMatchTolerance, `Images are not same`).to.be.true);
 }
 
 describe('Feature: Product Description Page', () => {
   context('Product container check', () => {
-    const productId = '253807413'
+    const unavailableProductId = '253558033'
     before(() => {
-      PDP.open(productId);
+      PDP.open(unavailableProductId);
     });
 
-    it('product container elements should be aligned properly', () => {
+    it('product container elements should be correct for an unavailable product', () => {
       compareImages(browser.checkElement(PDP.pdp_container.selector));
     });
   });


### PR DESCRIPTION
- [x] updated test to check for an unavailable PDP page
- [x] `isWithinMisMatchTolerance` assertion instead of `isExactSameImage`